### PR TITLE
Add doc describing test strategies for font parsing

### DIFF
--- a/text/2023-1-24-testing-read.md
+++ b/text/2023-1-24-testing-read.md
@@ -1,0 +1,77 @@
+## Testing strategies for font parsing
+
+Along with the safety guarantees provided by the Rust language, we also aim to 
+provide robust testing support to ensure that we agree with the 
+[specification](https://learn.microsoft.com/en-us/typography/opentype/spec/),
+match the outputs of existing high quality implementations such as [FreeType](https://freetype.org/)
+and [HarfBuzz](https://github.com/harfbuzz/harfbuzz), and avoid regressions.
+
+### read-fonts: low level parsing
+
+The [read-fonts](https://github.com/googlefonts/fontations/tree/main/read-fonts) crate consists primarily
+of generated code and is limited to parsing so the tests are generally scoped to ensuring correct
+extraction of typed values from binary font data. It contains inline unit tests for each table and subtable. 
+
+These are generally in one of two forms:
+* Scraped from examples in the specification such as this (`GPOS`) `SinglePosFormat2` subtable
+[example](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#example-3-singleposformat2-subtable)
+which is embedded in our [test data](https://github.com/googlefonts/fontations/blob/12fe04eb7083faaf8972720629496c0ca9a4b6c5/read-fonts/src/tests/test_data.rs#L17).
+* Hand written and designed to test against a [curated collection of fonts](https://github.com/googlefonts/fontations/tree/main/resources/test_fonts). An example of this for the `STAT` table can be found [here](https://github.com/googlefonts/fontations/blob/12fe04eb7083faaf8972720629496c0ca9a4b6c5/read-fonts/src/tables/stat.rs#L13).
+
+### punchcut: loading and scaling of glyph outlines
+
+Unlike `read-fonts`, the `punchcut` crate provides additional processing of the parsed data and the
+goal is to match the output of FreeType for loaded outlines
+
+The testing strategy for this library is to use a pinned version of FreeType (currently 2.12.0) to generate
+a text file containing the outline data in both raw (contours, points and tags as defined in
+[FT_Outline](https://freetype.org/freetype2/docs/reference/ft2-outline_processing.html#ft_outline)) and 
+decomposed path segment forms.
+
+Each outline in the text file is represented by the pattern:
+```
+glyph <glyph-id> <font-size> <hint-mode>
+points <points>
+contours <contours>
+tags <tags>
+m|l|q|c <points>
+-
+```
+With the following values:
+* `glyph-id`: the glyph indentifier
+* `font-size`: size in pixels per em. A size of 0 means unscaled
+* `hint-mode`: one of `none`, `full`, `light`, or `light-subpixel`
+* `points`: space separated list of points in `x, y` format
+* `contours` and `tags`: space separated list of integers representing contour end point 
+    indices and tag bits, respectively
+* `m`, `l`, `q`, `c`: path commands for `move to`, `line to`, `quad to` and `cubic to`, 
+    respectively
+
+The pattern ends with a single `-`.
+
+While testing, `punchcut` will read this text file and the associated font, loading each
+specified glyph according to the parameters and compare the outline data. This is done 
+for both raw outlines and paths, testing both our loading/scaling code and our path
+decomposition code.
+
+#### Exemplars
+
+Our collection of test fonts and glyphs is currently small. Our plan to grow this is to write
+a tool to generate a collection of exemplar glyphs that contain "interesting" characteristics
+that exercise the more complicated parts of the loading process. In particular, we are interested
+in glyphs that:
+* Contain multiple levels of composite nesting
+* Make use of the available component transform modes (`WE_HAVE_A_SCALE`, `WE_HAVE_AN_X_AND_Y_SCALE`, `WE_HAVE_A_TWO_BY_TWO`)
+* Apply a scale to a component offset (`SCALED_COMPONENT_OFFSET`)
+* Specify the `USE_MY_METRICS` flag to override base metrics with those of a component
+
+This will be done with a python script to collect the appropriate glyphs from a large set of 
+fonts. These will be pared down to the interesting cases and added to our test font resources.
+
+### feta: font metadata 
+
+The `feta` crate is planned and is designed to provide a high level interface to font metadata such
+as font metrics, glyph metrics, localized strings, character mapping, etc.
+
+Due to its nature of processing the parsed data, testing for this crate will be similar to that of
+`punchcut` and details on the extracted data format will be added here when they are established.

--- a/text/2023-1-24-testing-read.md
+++ b/text/2023-1-24-testing-read.md
@@ -18,10 +18,12 @@ These are generally in one of two forms:
 which is embedded in our [test data](https://github.com/googlefonts/fontations/blob/12fe04eb7083faaf8972720629496c0ca9a4b6c5/read-fonts/src/tests/test_data.rs#L17).
 * Hand written and designed to test against a [curated collection of fonts](https://github.com/googlefonts/fontations/tree/main/resources/test_fonts). An example of this for the `STAT` table can be found [here](https://github.com/googlefonts/fontations/blob/12fe04eb7083faaf8972720629496c0ca9a4b6c5/read-fonts/src/tables/stat.rs#L13).
 
-### punchcut: loading and scaling of glyph outlines
+### skrifa: metadata processing and loading/scaling of glyph outlines
 
-Unlike `read-fonts`, the `punchcut` crate provides additional processing of the parsed data and the
-goal is to match the output of FreeType for loaded outlines
+Unlike `read-fonts`, the `skrifa` crate provides additional processing of the parsed data and the
+goal is to match the output of FreeType for metadata, metrics and loaded outlines.
+
+#### Glyph loading/scaling
 
 The testing strategy for this library is to use a pinned version of FreeType (currently 2.12.0) to generate
 a text file containing the outline data in both raw (contours, points and tags as defined in
@@ -31,6 +33,7 @@ decomposed path segment forms.
 Each outline in the text file is represented by the pattern:
 ```
 glyph <glyph-id> <font-size> <hint-mode>
+coords <coords>
 points <points>
 contours <contours>
 tags <tags>
@@ -41,6 +44,7 @@ With the following values:
 * `glyph-id`: the glyph indentifier
 * `font-size`: size in pixels per em. A size of 0 means unscaled
 * `hint-mode`: one of `none`, `full`, `light`, or `light-subpixel`
+* `coords`: space separated list of normalized design coordinates, one per axis
 * `points`: space separated list of points in `x, y` format
 * `contours` and `tags`: space separated list of integers representing contour end point 
     indices and tag bits, respectively
@@ -49,10 +53,16 @@ With the following values:
 
 The pattern ends with a single `-`.
 
-While testing, `punchcut` will read this text file and the associated font, loading each
+While testing, `skrifa` will read this text file and the associated font, loading each
 specified glyph according to the parameters and compare the outline data. This is done 
 for both raw outlines and paths, testing both our loading/scaling code and our path
 decomposition code.
+
+#### Metadata and metrics
+
+The exact formats haven't been determined yet, but we aim to do similar FreeType extraction for
+metadata and metrics. The specific concerns here are character map selection, reading localized
+strings and extracting font and glyph metrics.
 
 #### Exemplars
 
@@ -67,11 +77,3 @@ in glyphs that:
 
 This will be done with a python script to collect the appropriate glyphs from a large set of 
 fonts. These will be pared down to the interesting cases and added to our test font resources.
-
-### feta: font metadata 
-
-The `feta` crate is planned and is designed to provide a high level interface to font metadata such
-as font metrics, glyph metrics, localized strings, character mapping, etc.
-
-Due to its nature of processing the parsed data, testing for this crate will be similar to that of
-`punchcut` and details on the extracted data format will be added here when they are established.


### PR DESCRIPTION
Where we describe the current and planned state of testing for font parsing

[rendered](https://github.com/dfrg/oxidize/blob/testing-doc/text/2023-1-24-testing-read.md)